### PR TITLE
ci(release): use NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,5 @@ jobs:
         id: release
         uses: ahmadnassri/action-semantic-release@v2.2.3
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use NODE_AUTH_TOKEN as suggested by
https://github.com/semantic-release/semantic-release/issues/2313