### PR TITLE
feat!: configure default retryCondition to retry more

### DIFF
--- a/lib/http.module.ts
+++ b/lib/http.module.ts
@@ -6,6 +6,7 @@ import axiosRetry, { exponentialDelay } from 'axios-retry';
 
 import { AXIOS_INSTANCE_TOKEN, HTTP_MODULE_ID, HTTP_MODULE_OPTIONS } from './http.constants';
 import { HttpService } from './http.service';
+import { isNetworkOrIdempotentRequestOrGatewayOrRateLimitError } from './http.util';
 import type {
   HttpModuleAsyncOptions,
   HttpModuleOptions,
@@ -18,6 +19,7 @@ const createAxiosInstance = (config?: HttpModuleOptions) => {
   axiosRetry(axiosInstance, {
     // Default exponential backoff
     retryDelay: exponentialDelay,
+    retryCondition: isNetworkOrIdempotentRequestOrGatewayOrRateLimitError,
     onRetry(retryCount, error, requestConfig) {
       logger.warn(
         {

--- a/lib/http.util.ts
+++ b/lib/http.util.ts
@@ -5,6 +5,12 @@ export function isGatewayError(error: AxiosError): boolean {
   return !!error.response && error.response.status >= 502 && error.response.status <= 504;
 }
 
-export function isNetworkOrIdempotentRequestOrGatewayError(error: AxiosError): boolean {
-  return isNetworkOrIdempotentRequestError(error) || isGatewayError(error);
+export function isRateLimitError(error: AxiosError): boolean {
+  return !!error.response && error.response.status === 429;
+}
+
+export function isNetworkOrIdempotentRequestOrGatewayOrRateLimitError(error: AxiosError): boolean {
+  return (
+    isNetworkOrIdempotentRequestError(error) || isGatewayError(error) || isRateLimitError(error)
+  );
 }


### PR DESCRIPTION
Configure the default retryCondition to retry by default on gateway
errors or rate limit errors